### PR TITLE
Handle data types better and reduce the number of type conversions

### DIFF
--- a/docs/RoutingSwitch-splittertransform.md
+++ b/docs/RoutingSwitch-splittertransform.md
@@ -49,7 +49,7 @@ Supported Basic Functions
 |Equals|`equals`|Checks for text equality|`equals(supplierA)`|
 |Not Equals|`not_equals`|Checks for text inequality|`not_equals(supplierA)`|
 |Contains|`contains`|Checks if the provided parameter is a substring of the data value|`contains(supp)`|
-|Not Contains|`not_contains`Checks if the provided parameter is not a substring of the data value|`not_contains(flip)`|
+|Not Contains|`not_contains`|Checks if the provided parameter is not a substring of the data value|`not_contains(flip)`|
 |In|`in`|Checks if the data value is contained in a pipe-delimited list provided as an the parameter|`in(supplierA\|supplierB)`|
 |Not In|`not_in`|Checks if the data value is not contained in a pipe-delimited list provided as an the parameter|`not_in(supplierA\|supplierB)`|
 |Matches|`matches`|Checks if the data matches the provided regular expression. Supports [Java regular expression syntax](https://docs.oracle.com/javase/tutorial/essential/regex/).|`matches(.*lierA$)`|
@@ -61,8 +61,30 @@ Supported Basic Functions
 |Number Equals|`number_equals`|Checks if the data value is a number that equals the provided parameter. Supports the Java Numeric data types.|`number_equals(234523)`|
 |Number Not Equals|`number_not_equals`|Checks if the data value is a number that does not equal the provided parameter. Both the data and the provided parameter should be a number. Supports the Java Numeric data types.|`number_not_equals(234523)`|
 |Number Greater Than|`number_greater_than`|Checks if the data value is a number that is greater than the provided parameter. Both the data and the provided parameter should be a number. Supports the Java Numeric data types.|`number_greater_than(234523)`|
-|Number Greater Than or Equals|`number_greater_than_or_equals`|Checks if the data value is a number that is greater than or equal to the provided parameter. Both the data and the provided parameter should be a number. Supports the Java Numeric data types.|`number_not_equals(234523)`|
-|Number Lesser Than|`number_lesser_than`|Checks if the data value is a number that is lesser than the provided parameter. Both the data and the provided parameter should be a number. Supports the Java Numeric data types.|`number_greater_than(234523)`|
-|Number Lesser Than or Equals|`number_lesser_than_or_equals`|Checks if the data value is a number that is lesser than or equal to the provided parameter. Both the data and the provided parameter should be a number. Supports the Java Numeric data types.|`number_not_equals(234523)`|
+|Number Greater Than or Equals|`number_greater_than_or_equals`|Checks if the data value is a number that is greater than or equal to the provided parameter. Both the data and the provided parameter should be a number. Supports the Java Numeric data types.|`number_greater_than_or_equals(234523)`|
+|Number Lesser Than|`number_lesser_than`|Checks if the data value is a number that is lesser than the provided parameter. Both the data and the provided parameter should be a number. Supports the Java Numeric data types.|`number_lesser_than(234523)`|
+|Number Lesser Than or Equals|`number_lesser_than_or_equals`|Checks if the data value is a number that is lesser than or equal to the provided parameter. Both the data and the provided parameter should be a number. Supports the Java Numeric data types.|`number_lesser_than_or_equals(234523)`|
 |Number Between|`number_between`|Checks if the data value is a number that is between a lower bound and an upper bound (both inclusive) specified in the provided parameter. The lower bound and upper bound should be specified as pipe-delimited in the parameter.|`number_between(234\|523)`|
 |Number Not Between|`number_not_between`|Checks if the data value is a number that is not between a lower bound and an upper bound (both exclusive) specified in the provided parameter. The lower bound and upper bound should be specified as pipe-delimited in the parameter.|`number_not_between(234\|523)`|
+|Date Equals|`date_equals`|Checks if the data value is a date that equals the provided parameter. The date should be specified using one of the ISO-8601 date formats indicated in the table below.|`date_equals(2020-05-04)`|
+|Date Not Equals|`date_not_equals`|Checks if the data value is a date that does not equal the provided parameter. Both the data and the provided parameter should be a date. The date should be specified using one of the ISO-8601 date formats indicated in the table below.|`date_not_equals(10:15:30)`|
+|Date After|`date_greater_than`|Checks if the data value is a date that is greater than the provided parameter. Both the data and the provided parameter should be a date. The date should be specified using one of the ISO-8601 date formats indicated in the table below.|`date_after(2020-05-02T00:03:20-07:00[America/Los_Angeles])`|
+|Date After or On|`date_greater_than_or_equals`|Checks if the data value is a date that is greater than or equal to the provided parameter. Both the data and the provided parameter should be a date. The date should be specified using one of the ISO-8601 date formats indicated in the table below.|`date_after_or_on(10:15:30)`|
+|Date Before|`date_lesser_than`|Checks if the data value is a date that is lesser than the provided parameter. Both the data and the provided parameter should be a date. The date should be specified using one of the ISO-8601 date formats indicated in the table below.|`date_before(2020-05-02T00:03:20-07:00[America/Los_Angeles])`|
+|Date Before or On|`date_lesser_than_or_equals`|Checks if the data value is a date that is lesser than or equal to the provided parameter. Both the data and the provided parameter should be a date. The date should be specified using one of the ISO-8601 date formats indicated in the table below.|`date_before_or_on(10:15:30)`|
+|Date Between|`date_between`|Checks if the data value is a date that is between a lower bound and an upper bound (both inclusive) specified in the provided parameter. The lower bound and upper bound should be specified as pipe-delimited in the parameter.|`date_between(2020-05-04\|2020-05-04)`|
+|Date Not Between|`date_not_between`|Checks if the data value is a date that is not between a lower bound and an upper bound (both exclusive) specified in the provided parameter. The lower bound and upper bound should be specified as pipe-delimited in the parameter.|`date_not_between(2020-05-04\|2020-05-05)`|
+
+
+Date Formats
+------------
+The date parameters to the Date-based functions above should be specified using one of the following ISO-8601 date 
+formats. Note that you should choose the appropriate format based on the type of the routing field in the schema.
+
+|Routing Field Type|ISO-8601 Date Format|Example|
+|------------------|--------------------|-------|
+|Date|YYYY-MM-dd|`2020-05-04`|
+|Time Millis|hh:mm:ss|`00:03:20`|
+|Time Micros|hh:mm:ss|`00:03:20`|
+|Timestamp Millis|YYYY-MM-ddThh:mm:ssZ|`2020-05-02T00:03:20-07:00[America/Los_Angeles]`|
+|Timestamp Micros|YYYY-MM-ddThh:mm:ssZ|`2020-05-02T00:03:20-07:00[America/Los_Angeles]`|

--- a/src/main/java/io/cdap/plugin/switchcase/route/BasicPortSpecification.java
+++ b/src/main/java/io/cdap/plugin/switchcase/route/BasicPortSpecification.java
@@ -63,17 +63,47 @@ final class BasicPortSpecification extends PortSpecification {
       RoutingSwitch.Config.FunctionType.NUMBER_NOT_BETWEEN,
       new BasicRoutingFunctions.NumberNotBetweenFunction()
     );
+    FUNCTIONS.put(
+      RoutingSwitch.Config.FunctionType.DATE_EQUALS,
+      new BasicRoutingFunctions.DateEqualsFunction()
+    );
+    FUNCTIONS.put(
+      RoutingSwitch.Config.FunctionType.DATE_NOT_EQUALS,
+      new BasicRoutingFunctions.DateNotEqualsFunction()
+    );
+    FUNCTIONS.put(
+      RoutingSwitch.Config.FunctionType.DATE_AFTER,
+      new BasicRoutingFunctions.DateAfterFunction()
+    );
+    FUNCTIONS.put(
+      RoutingSwitch.Config.FunctionType.DATE_AFTER_OR_ON,
+      new BasicRoutingFunctions.DateAfterOrOnFunction()
+    );
+    FUNCTIONS.put(
+      RoutingSwitch.Config.FunctionType.DATE_BEFORE,
+      new BasicRoutingFunctions.DateBeforeFunction()
+    );
+    FUNCTIONS.put(
+      RoutingSwitch.Config.FunctionType.DATE_BEFORE_OR_ON,
+      new BasicRoutingFunctions.DateBeforeOrOnFunction()
+    );
+    FUNCTIONS.put(
+      RoutingSwitch.Config.FunctionType.DATE_BETWEEN,
+      new BasicRoutingFunctions.DateBetweenFunction()
+    );
+    FUNCTIONS.put(
+      RoutingSwitch.Config.FunctionType.DATE_NOT_BETWEEN,
+      new BasicRoutingFunctions.DateNotBetweenFunction()
+    );
   }
   private final BasicRoutingFunction routingFunction;
   private final String parameter;
-  private final FailureCollector collector;
 
   BasicPortSpecification(String name, RoutingSwitch.Config.FunctionType functionType, String parameter,
                          FailureCollector collector) {
     super(name);
-    this.routingFunction = fromFunctionType(functionType);
+    this.routingFunction = fromFunctionType(functionType, collector);
     this.parameter = parameter;
-    this.collector = collector;
   }
 
   BasicRoutingFunction getRoutingFunction() {
@@ -84,7 +114,8 @@ final class BasicPortSpecification extends PortSpecification {
     return parameter;
   }
 
-  private BasicRoutingFunction fromFunctionType(RoutingSwitch.Config.FunctionType functionType) {
+  private BasicRoutingFunction fromFunctionType(RoutingSwitch.Config.FunctionType functionType,
+                                                FailureCollector collector) {
     if (!FUNCTIONS.containsKey(functionType)) {
         collector.addFailure(
           "Unknown routing function " + functionType,

--- a/src/main/java/io/cdap/plugin/switchcase/route/BasicRoutingFunction.java
+++ b/src/main/java/io/cdap/plugin/switchcase/route/BasicRoutingFunction.java
@@ -16,6 +16,8 @@
 
 package io.cdap.plugin.switchcase.route;
 
+import io.cdap.cdap.api.data.schema.Schema;
+
 /**
  * Defines the contract for a routing function, which decides  which port to route a record to
  */
@@ -25,7 +27,10 @@ public interface BasicRoutingFunction {
    *
    * @param actualValue the value to evaluate
    * @param compareValue the value to evaluate against
+   * @param schema the {@link Schema} of the routing field as defined in the record schema. The
+   *                {@link Schema.Type Type} or {@link Schema.LogicalType Logical Type} of the routing field as defined
+   *                in the record schema is used for parsing the data.
    * @return true if the condition is satisfied, false otherwise
    */
-  boolean evaluate(String actualValue, String compareValue);
+  boolean evaluate(Object actualValue, String compareValue, Schema schema);
 }

--- a/src/main/java/io/cdap/plugin/switchcase/route/BasicRoutingFunctions.java
+++ b/src/main/java/io/cdap/plugin/switchcase/route/BasicRoutingFunctions.java
@@ -16,9 +16,15 @@
 
 package io.cdap.plugin.switchcase.route;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Class that contains various implementations of {@link BasicRoutingFunction}
@@ -31,7 +37,8 @@ final class BasicRoutingFunctions {
   static class EqualsFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Equals");
       return compareValue.equals(actualValue);
     }
   }
@@ -42,7 +49,8 @@ final class BasicRoutingFunctions {
   static class NotEqualsFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Not Equals");
       return !compareValue.equals(actualValue);
     }
   }
@@ -53,8 +61,9 @@ final class BasicRoutingFunctions {
   static class ContainsFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      return actualValue.contains(compareValue);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Contains");
+      return ((String) actualValue).contains(compareValue);
     }
   }
 
@@ -64,8 +73,9 @@ final class BasicRoutingFunctions {
   static class NotContainsFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      return !actualValue.contains(compareValue);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Not Contains");
+      return !((String) actualValue).contains(compareValue);
     }
   }
 
@@ -75,8 +85,10 @@ final class BasicRoutingFunctions {
   static class InFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "In");
       List<String> possibleValues = Arrays.asList(compareValue.split("\\|"));
+      //noinspection SuspiciousMethodCalls
       return possibleValues.contains(actualValue);
     }
   }
@@ -87,8 +99,10 @@ final class BasicRoutingFunctions {
   static class NotInFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Not In");
       List<String> possibleValues = Arrays.asList(compareValue.split("\\|"));
+      //noinspection SuspiciousMethodCalls
       return !possibleValues.contains(actualValue);
     }
   }
@@ -99,8 +113,9 @@ final class BasicRoutingFunctions {
   static class MatchesFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      return actualValue.matches(compareValue);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Matches");
+      return ((String) actualValue).matches(compareValue);
     }
   }
 
@@ -110,8 +125,9 @@ final class BasicRoutingFunctions {
   static class NotMatchesFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      return !actualValue.matches(compareValue);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Not Matches");
+      return !((String) actualValue).matches(compareValue);
     }
   }
 
@@ -121,8 +137,9 @@ final class BasicRoutingFunctions {
   static class StartsWithFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      return actualValue.startsWith(compareValue);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Starts With");
+      return ((String) actualValue).startsWith(compareValue);
     }
   }
 
@@ -132,8 +149,9 @@ final class BasicRoutingFunctions {
   static class NotStartsWithFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      return !actualValue.startsWith(compareValue);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Not Starts With");
+      return !((String) actualValue).startsWith(compareValue);
     }
   }
 
@@ -143,8 +161,9 @@ final class BasicRoutingFunctions {
   static class EndsWithFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      return actualValue.endsWith(compareValue);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Ends With");
+      return ((String) actualValue).endsWith(compareValue);
     }
   }
 
@@ -154,8 +173,9 @@ final class BasicRoutingFunctions {
   static class NotEndsWithFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      return !actualValue.endsWith(compareValue);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      ensureString(actualValue, getNonNullableType(schema), "Not Ends With");
+      return !((String) actualValue).endsWith(compareValue);
     }
   }
 
@@ -165,10 +185,8 @@ final class BasicRoutingFunctions {
   static class NumberEqualsFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      BigDecimal actualNumber = parseNumber(actualValue, "Number Equals");
-      BigDecimal compareNumber = parseNumber(compareValue, "Number Equals");
-      return actualNumber.equals(compareNumber);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      return compare(actualValue, compareValue, schema, "Equals") == 0;
     }
   }
 
@@ -178,10 +196,8 @@ final class BasicRoutingFunctions {
   static class NumberNotEqualsFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      BigDecimal actualNumber = parseNumber(actualValue, "Number Not Equals");
-      BigDecimal compareNumber = parseNumber(compareValue, "Number Not Equals");
-      return !actualNumber.equals(compareNumber);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      return compare(actualValue, compareValue, schema, "Not Equals") != 0;
     }
   }
 
@@ -191,10 +207,8 @@ final class BasicRoutingFunctions {
   static class GreaterThanFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      BigDecimal actualNumber = parseNumber(actualValue, "Number Greater Than");
-      BigDecimal compareNumber = parseNumber(compareValue, "Number Greater Than");
-      return actualNumber.compareTo(compareNumber) > 0;
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      return compare(actualValue, compareValue, schema, "Greater Than") > 0;
     }
   }
 
@@ -204,10 +218,8 @@ final class BasicRoutingFunctions {
   static class GreaterThanOrEqualsFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      BigDecimal actualNumber = parseNumber(actualValue, "Number Greater Than or Equals");
-      BigDecimal compareNumber = parseNumber(compareValue, "Number Greater Than or Equals");
-      return actualNumber.compareTo(compareNumber) >= 0;
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      return compare(actualValue, compareValue, schema, "Greater Than or Equals") >= 0;
     }
   }
 
@@ -217,10 +229,8 @@ final class BasicRoutingFunctions {
   static class LesserThanFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      BigDecimal actualNumber = parseNumber(actualValue, "Number Greater Than");
-      BigDecimal compareNumber = parseNumber(compareValue, "Number Greater Than");
-      return actualNumber.compareTo(compareNumber) < 0;
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      return compare(actualValue, compareValue, schema, "Less Than") < 0;
     }
   }
 
@@ -230,10 +240,8 @@ final class BasicRoutingFunctions {
   static class LesserThanOrEqualsFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      BigDecimal actualNumber = parseNumber(actualValue, "Number Greater Than or Equals");
-      BigDecimal compareNumber = parseNumber(compareValue, "Number Greater Than or Equals");
-      return actualNumber.compareTo(compareNumber) <= 0;
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      return compare(actualValue, compareValue, schema, "Less Than or Equals") <= 0;
     }
   }
 
@@ -243,8 +251,8 @@ final class BasicRoutingFunctions {
   static class NumberBetweenFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      return checkNumberBetween(actualValue, compareValue);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      return checkNumberBetween(actualValue, compareValue, schema, "Number Between");
     }
   }
 
@@ -254,34 +262,269 @@ final class BasicRoutingFunctions {
   static class NumberNotBetweenFunction implements BasicRoutingFunction {
 
     @Override
-    public boolean evaluate(String actualValue, String compareValue) {
-      return !checkNumberBetween(actualValue, compareValue);
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      return !checkNumberBetween(actualValue, compareValue, schema, "Number Not Between");
     }
   }
 
-  private static BigDecimal parseNumber(String value, String function) {
-    BigDecimal returnValue;
+  /**
+   * Routing function that checks for date equality
+   */
+  static class DateEqualsFunction implements BasicRoutingFunction {
+
+    @Override
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      Schema.LogicalType logicalType = Objects.requireNonNull(schema.getLogicalType());
+      return compareDate(actualValue, compareValue, logicalType, "Date Equals") == 0;
+    }
+  }
+
+  /**
+   * Routing function that checks for date inequality
+   */
+  static class DateNotEqualsFunction implements BasicRoutingFunction {
+
+    @Override
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      Schema.LogicalType logicalType = Objects.requireNonNull(schema.getLogicalType());
+      return compareDate(actualValue, compareValue, logicalType, "Date Not Equals") != 0;
+    }
+  }
+
+  /**
+   * Routing function that checks for a date value being before a specified date (exclusive)
+   */
+  static class DateBeforeFunction implements BasicRoutingFunction {
+
+    @Override
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      Schema.LogicalType logicalType = Objects.requireNonNull(schema.getLogicalType());
+      return compareDate(actualValue, compareValue, logicalType, "Date Before") < 0;
+    }
+  }
+
+  /**
+   * Routing function that checks for a date value being before a specified date (inclusive)
+   */
+  static class DateBeforeOrOnFunction implements BasicRoutingFunction {
+
+    @Override
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      Schema.LogicalType logicalType = Objects.requireNonNull(schema.getLogicalType());
+      return compareDate(actualValue, compareValue, logicalType, "Date Before or On") <= 0;
+    }
+  }
+
+  /**
+   * Routing function that checks for a date value being after a specified date (exclusive)
+   */
+  static class DateAfterFunction implements BasicRoutingFunction {
+
+    @Override
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      Schema.LogicalType logicalType = Objects.requireNonNull(schema.getLogicalType());
+      return compareDate(actualValue, compareValue, logicalType, "Date After") > 0;
+    }
+  }
+
+  /**
+   * Routing function that checks for a date value being after a specified date (inclusive)
+   */
+  static class DateAfterOrOnFunction implements BasicRoutingFunction {
+
+    @Override
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      Schema.LogicalType logicalType = Objects.requireNonNull(schema.getLogicalType());
+      return compareDate(actualValue, compareValue, logicalType, "Date After or On") >= 0;
+    }
+  }
+
+  /**
+   * Routing function that checks for a date value being between two specified dates (inclusive)
+   */
+  static class DateBetweenFunction implements BasicRoutingFunction {
+
+    @Override
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      Schema.LogicalType logicalType = Objects.requireNonNull(schema.getLogicalType());
+      return checkDateBetween(actualValue, compareValue, logicalType, "Date Between");
+    }
+  }
+
+  /**
+   * Routing function that checks for a date value not being between two specified dates (inclusive)
+   */
+  static class DateNotBetweenFunction implements BasicRoutingFunction {
+
+    @Override
+    public boolean evaluate(Object actualValue, String compareValue, Schema schema) {
+      Schema.LogicalType logicalType = Objects.requireNonNull(schema.getLogicalType());
+      return !checkDateBetween(actualValue, compareValue, logicalType, "Date Not Between");
+    }
+  }
+
+  private static Schema.Type getNonNullableType(Schema schema) {
+    return schema.isNullable() ? schema.getNonNullable().getType() : schema.getType();
+  }
+
+  private static void ensureString(Object actualValue, Schema.Type type, String function) {
+    if (!(actualValue instanceof String) && !(type == Schema.Type.STRING)) {
+      throw new IllegalArgumentException(
+        String.format("Function %s can only be called on Strings. Found data type %s and schema type %s",
+                      function, actualValue.getClass().getName(), type)
+      );
+    }
+  }
+
+  private static int compare(Object actualValue, String compareValue, Schema schema, String function) {
+    Schema.Type type = getNonNullableType(schema);
+    switch (type) {
+      case INT:
+        return ((Integer) actualValue).compareTo(parseInt(compareValue, function));
+      case DOUBLE:
+        return ((Double) actualValue).compareTo(parseDouble(compareValue, function));
+      case FLOAT:
+        return ((Float) actualValue).compareTo(parseFloat(compareValue, function));
+      case LONG:
+        return ((Long) actualValue).compareTo(parseLong(compareValue, function));
+      case BYTES:
+        // ensure decimal type
+        if (schema.getLogicalType() == null) {
+          throw new IllegalArgumentException(
+            String.format("Routing function %s is not supported on bytes fields.", function)
+          );
+        }
+        if (Schema.LogicalType.DECIMAL != schema.getLogicalType()) {
+          throw new IllegalArgumentException(
+            String.format("Routing function %s must be called on a field with logical type as decimal.", function)
+          );
+        }
+        BigDecimal actualDecimal = (BigDecimal) actualValue;
+        BigDecimal compareDecimal = parseDecimal(compareValue, function);
+        return actualDecimal.compareTo(compareDecimal);
+      default:
+        throw new IllegalArgumentException(
+          String.format("Numeric function %s called on non-numeric type %s", function, type)
+        );
+    }
+  }
+
+  private static boolean checkNumberBetween(Object actualValue, String compareValue, Schema schema, String function) {
+    String[] bounds = parseRange(compareValue);
+    return compare(actualValue, bounds[0], schema, function) >= 0 &&
+      compare(actualValue, bounds[1], schema, function) <= 0;
+  }
+
+  private static Integer parseInt(String value, String function) {
+    int returnValue;
     try {
-      returnValue = new BigDecimal(value);
+      returnValue = Integer.parseInt(value);
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(
-        String.format("Expected number, but found non-numeric argument '%s' for function %s", value, function)
+        String.format("Expected integer, but found argument '%s' for function %s", value, function)
       );
     }
     return returnValue;
   }
 
-  private static boolean checkNumberBetween(String actualValue, String compareValue) {
-    String[] bounds = compareValue.split("\\|");
-    if (bounds.length != 2) {
+  private static Long parseLong(String value, String function) {
+    long returnValue;
+    try {
+      returnValue = Long.parseLong(value);
+    } catch (NumberFormatException e) {
       throw new IllegalArgumentException(
-        String.format("Should specify a lower bound and upper bound separated by a pipe. Found %s.", compareValue)
+        String.format("Expected long, but found argument '%s' for function %s", value, function)
       );
     }
-    BigDecimal lower = parseNumber(bounds[0], "Number Between");
-    BigDecimal upper = parseNumber(bounds[1], "Number Between");
-    BigDecimal actual = parseNumber(actualValue, "Number Between");
-    return actual.compareTo(lower) >= 0 && actual.compareTo(upper) <= 0;
+    return returnValue;
+  }
+
+  private static Float parseFloat(String value, String function) {
+    float returnValue;
+    try {
+      returnValue = Float.parseFloat(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+        String.format("Expected float, but found argument '%s' for function %s", value, function)
+      );
+    }
+    return returnValue;
+  }
+
+  private static Double parseDouble(String value, String function) {
+    double returnValue;
+    try {
+      returnValue = Double.parseDouble(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+        String.format("Expected double, but found argument '%s' for function %s", value, function)
+      );
+    }
+    return returnValue;
+  }
+
+  private static BigDecimal parseDecimal(String value, String function) {
+    BigDecimal returnValue;
+    try {
+      returnValue = new BigDecimal(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+        String.format("Expected BigDecimal, but found argument '%s' for function %s", value, function)
+      );
+    }
+    return returnValue;
+  }
+
+  private static int compareDate(Object actualValue, String compareValue, Schema.LogicalType logicalType,
+                                 String function) {
+    switch(logicalType) {
+      case DATE:
+        LocalDate actualDate = (LocalDate) actualValue;
+        LocalDate compareDate = LocalDate.parse(compareValue, DateTimeFormatter.ISO_LOCAL_DATE);
+        return actualDate.compareTo(compareDate);
+      case TIME_MILLIS:
+        LocalTime actualTime = (LocalTime) actualValue;
+        LocalTime compareTime = LocalTime.parse(compareValue, DateTimeFormatter.ISO_LOCAL_TIME);
+        return actualTime.compareTo(compareTime);
+      case TIME_MICROS:
+        actualTime = (LocalTime) actualValue;
+        compareTime = LocalTime.parse(compareValue, DateTimeFormatter.ISO_LOCAL_TIME);
+        return actualTime.compareTo(compareTime);
+      // NOTE: For timestamps, can't use ISO_LOCAL_DATE_TIME, because in Java 8, ZonedDateTime.parse() fails if the
+      // input does not contain a zone (https://bugs.openjdk.java.net/browse/JDK-8033662). So you have to explicitly
+      // specify a zone, and use the ISO_ZONED_DATE_TIME formatter. E.g. the input
+      // "2020-05-02T00:03:19-07:00[America/Los_Angeles]" will work, but the input
+      // "2020-05-02T00:03:19" (without timezone) will not work.
+      case TIMESTAMP_MILLIS:
+        ZonedDateTime actualTimestamp = (ZonedDateTime) actualValue;
+        ZonedDateTime compareTimestamp = ZonedDateTime.parse(compareValue, DateTimeFormatter.ISO_ZONED_DATE_TIME);
+        return actualTimestamp.compareTo(compareTimestamp);
+      case TIMESTAMP_MICROS:
+        actualTimestamp = (ZonedDateTime) actualValue;
+        compareTimestamp = ZonedDateTime.parse(compareValue, DateTimeFormatter.ISO_ZONED_DATE_TIME);
+        return actualTimestamp.compareTo(compareTimestamp);
+      default:
+        throw new IllegalArgumentException(
+          String.format("Date function %s called on non-date type %s", function, logicalType)
+        );
+    }
+  }
+
+  private static boolean checkDateBetween(Object actualValue, String compareValue, Schema.LogicalType logicalType,
+                                          String function) {
+    String[] bounds = parseRange(compareValue);
+    return compareDate(actualValue, bounds[0], logicalType, function) >= 0 &&
+      compareDate(actualValue, bounds[1], logicalType, function) <= 0;
+  }
+
+  private static String[] parseRange(String input) {
+    String[] bounds = input.split("\\|");
+    if (bounds.length != 2) {
+      throw new IllegalArgumentException(
+        String.format("Should specify a lower bound and upper bound separated by a pipe. Found %s.", input)
+      );
+    }
+    return bounds;
   }
 
   private BasicRoutingFunctions() {

--- a/src/test/java/io/cdap/plugin/switchcase/route/BasicRoutingFunctionsTest.java
+++ b/src/test/java/io/cdap/plugin/switchcase/route/BasicRoutingFunctionsTest.java
@@ -16,8 +16,16 @@
 
 package io.cdap.plugin.switchcase.route;
 
+import io.cdap.cdap.api.data.schema.Schema;
 import org.junit.Assert;
 import org.junit.Test;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 
 /**
  * Tests for {@link BasicRoutingFunctions}
@@ -25,147 +33,287 @@ import org.junit.Test;
 public class BasicRoutingFunctionsTest {
   @Test
   public void testStringFunctions() {
+    Schema stringSchema = Schema.of(Schema.Type.STRING);
     BasicRoutingFunction function = new BasicRoutingFunctions.EqualsFunction();
-    Assert.assertTrue(function.evaluate("value", "value"));
-    Assert.assertFalse(function.evaluate("val", "value"));
+    Assert.assertTrue(function.evaluate("value", "value", stringSchema));
+    Assert.assertFalse(function.evaluate("val", "value", stringSchema));
     function = new BasicRoutingFunctions.NotEqualsFunction();
-    Assert.assertTrue(function.evaluate("val", "value"));
-    Assert.assertFalse(function.evaluate("value", "value"));
+    Assert.assertTrue(function.evaluate("val", "value", stringSchema));
+    Assert.assertFalse(function.evaluate("value", "value", stringSchema));
     function = new BasicRoutingFunctions.ContainsFunction();
-    Assert.assertTrue(function.evaluate("value", "val"));
-    Assert.assertFalse(function.evaluate("val", "value"));
+    Assert.assertTrue(function.evaluate("value", "val", stringSchema));
+    Assert.assertFalse(function.evaluate("val", "value", stringSchema));
     function = new BasicRoutingFunctions.NotContainsFunction();
-    Assert.assertTrue(function.evaluate("val", "value"));
-    Assert.assertFalse(function.evaluate("value", "val"));
+    Assert.assertTrue(function.evaluate("val", "value", stringSchema));
+    Assert.assertFalse(function.evaluate("value", "val", stringSchema));
     function = new BasicRoutingFunctions.InFunction();
-    Assert.assertTrue(function.evaluate("val", "val|value"));
-    Assert.assertFalse(function.evaluate("value", "val|val1"));
+    Assert.assertTrue(function.evaluate("val", "val|value", stringSchema));
+    Assert.assertFalse(function.evaluate("value", "val|val1", stringSchema));
     function = new BasicRoutingFunctions.NotInFunction();
-    Assert.assertTrue(function.evaluate("val", "value|value1"));
-    Assert.assertFalse(function.evaluate("val", "val|val1"));
+    Assert.assertTrue(function.evaluate("val", "value|value1", stringSchema));
+    Assert.assertFalse(function.evaluate("val", "val|val1", stringSchema));
     function = new BasicRoutingFunctions.StartsWithFunction();
-    Assert.assertTrue(function.evaluate("value", "val"));
-    Assert.assertFalse(function.evaluate("val", "value"));
+    Assert.assertTrue(function.evaluate("value", "val", stringSchema));
+    Assert.assertFalse(function.evaluate("val", "value", stringSchema));
     function = new BasicRoutingFunctions.NotStartsWithFunction();
-    Assert.assertTrue(function.evaluate("val", "value"));
-    Assert.assertFalse(function.evaluate("value", "val"));
+    Assert.assertTrue(function.evaluate("val", "value", stringSchema));
+    Assert.assertFalse(function.evaluate("value", "val", stringSchema));
     function = new BasicRoutingFunctions.EndsWithFunction();
-    Assert.assertTrue(function.evaluate("value", "lue"));
-    Assert.assertFalse(function.evaluate("value", "value1"));
+    Assert.assertTrue(function.evaluate("value", "lue", stringSchema));
+    Assert.assertFalse(function.evaluate("value", "value1", stringSchema));
     function = new BasicRoutingFunctions.NotEndsWithFunction();
-    Assert.assertTrue(function.evaluate("value", "value1"));
-    Assert.assertFalse(function.evaluate("value", "lue"));
+    Assert.assertTrue(function.evaluate("value", "value1", stringSchema));
+    Assert.assertFalse(function.evaluate("value", "lue", stringSchema));
     function = new BasicRoutingFunctions.MatchesFunction();
-    Assert.assertTrue(function.evaluate("value", ".*alu.*"));
-    Assert.assertFalse(function.evaluate("value", ".*al$"));
+    Assert.assertTrue(function.evaluate("value", ".*alu.*", stringSchema));
+    Assert.assertFalse(function.evaluate("value", ".*al$", stringSchema));
     function = new BasicRoutingFunctions.NotMatchesFunction();
-    Assert.assertTrue(function.evaluate("value", ".*al$"));
-    Assert.assertFalse(function.evaluate("value", ".*alu.*"));
+    Assert.assertTrue(function.evaluate("value", ".*al$", stringSchema));
+    Assert.assertFalse(function.evaluate("value", ".*alu.*", stringSchema));
   }
 
   @Test
   public void testNumericFunctions() {
+    Schema intSchema = Schema.of(Schema.Type.INT);
+    Schema longSchema = Schema.of(Schema.Type.LONG);
+    Schema floatSchema = Schema.of(Schema.Type.FLOAT);
+    Schema doubleSchema = Schema.of(Schema.Type.DOUBLE);
     BasicRoutingFunction function = new BasicRoutingFunctions.NumberEqualsFunction();
-    Assert.assertTrue(function.evaluate("999999999999", "999999999999"));
-    Assert.assertFalse(function.evaluate("999999999999", "9999999999999"));
+    Assert.assertTrue(function.evaluate(999999999999L, "999999999999", longSchema));
+    Assert.assertFalse(function.evaluate(999999999999L, "9999999999999", longSchema));
     try {
-      Assert.assertFalse(function.evaluate("9999", "val"));
+      Assert.assertFalse(function.evaluate(9999, "val", intSchema));
       Assert.fail("Expected function to fail for non-numeric value");
     } catch (IllegalArgumentException e) {
       // expected
     }
     function = new BasicRoutingFunctions.NumberNotEqualsFunction();
-    Assert.assertTrue(function.evaluate("999999999999", "99999999999999"));
-    Assert.assertFalse(function.evaluate("999999999999", "999999999999"));
+    Assert.assertTrue(function.evaluate(999999999, "99999", intSchema));
+    Assert.assertFalse(function.evaluate(999999999999L, "999999999999", longSchema));
     try {
-      Assert.assertFalse(function.evaluate("9999", "val"));
+      Assert.assertFalse(function.evaluate(9999, "val", intSchema));
       Assert.fail("Expected function to fail for non-numeric value");
     } catch (IllegalArgumentException e) {
       // expected
     }
     function = new BasicRoutingFunctions.GreaterThanFunction();
-    Assert.assertTrue(function.evaluate("999999999999", "999999"));
-    Assert.assertFalse(function.evaluate("999999", "999999999999"));
-    Assert.assertFalse(function.evaluate("999999999999", "999999999999"));
+    Assert.assertTrue(function.evaluate(3.14f, "3", floatSchema));
+    Assert.assertFalse(function.evaluate(3.14, "9.99999999999", doubleSchema));
+    Assert.assertFalse(function.evaluate(3.14, "3.14", doubleSchema));
     try {
-      Assert.assertFalse(function.evaluate("9999", "val"));
+      Assert.assertFalse(function.evaluate(9999, "val", intSchema));
       Assert.fail("Expected function to fail for non-numeric value");
     } catch (IllegalArgumentException e) {
       // expected
     }
     function = new BasicRoutingFunctions.GreaterThanOrEqualsFunction();
-    Assert.assertTrue(function.evaluate("999999999999", "999999"));
-    Assert.assertTrue(function.evaluate("999999999999", "999999999999"));
-    Assert.assertFalse(function.evaluate("999999", "999999999999"));
+    Assert.assertTrue(function.evaluate(999999999999L, "999999", longSchema));
+    Assert.assertTrue(function.evaluate(999999999999L, "999999999999", longSchema));
+    Assert.assertFalse(function.evaluate(999999, "99999999", intSchema));
     try {
-      Assert.assertFalse(function.evaluate("9999", "val"));
+      Assert.assertFalse(function.evaluate(9999, "val", intSchema));
       Assert.fail("Expected function to fail for non-numeric value");
     } catch (IllegalArgumentException e) {
       // expected
     }
     function = new BasicRoutingFunctions.LesserThanFunction();
-    Assert.assertTrue(function.evaluate("999999", "999999999999"));
-    Assert.assertFalse(function.evaluate("999999999999", "99999"));
-    Assert.assertFalse(function.evaluate("999999999999", "999999999999"));
+    Assert.assertTrue(function.evaluate(999999, "9999999", intSchema));
+    Assert.assertFalse(function.evaluate(99999, "999", intSchema));
+    Assert.assertFalse(function.evaluate(9.99999999999, "9.99999999999", doubleSchema));
     try {
-      Assert.assertFalse(function.evaluate("9999", "val"));
+      Assert.assertFalse(function.evaluate(9.999, "val", doubleSchema));
       Assert.fail("Expected function to fail for non-numeric value");
     } catch (IllegalArgumentException e) {
       // expected
     }
     function = new BasicRoutingFunctions.LesserThanOrEqualsFunction();
-    Assert.assertTrue(function.evaluate("999999", "999999999999"));
-    Assert.assertTrue(function.evaluate("999999999999", "999999999999"));
-    Assert.assertFalse(function.evaluate("999999999999", "999999"));
+    Assert.assertTrue(function.evaluate(999999, "99999999", intSchema));
+    Assert.assertTrue(function.evaluate(999999, "999999", intSchema));
+    Assert.assertFalse(function.evaluate(999999999999L, "999999", longSchema));
     try {
-      Assert.assertFalse(function.evaluate("9999", "val"));
+      Assert.assertFalse(function.evaluate(9999, "val", intSchema));
       Assert.fail("Expected function to fail for non-numeric value");
     } catch (IllegalArgumentException e) {
       // expected
     }
     function = new BasicRoutingFunctions.NumberBetweenFunction();
-    Assert.assertTrue(function.evaluate("999999", "99999|999999999999"));
-    Assert.assertTrue(function.evaluate("999999", "999999|999999999999"));
-    Assert.assertTrue(function.evaluate("999999", "9999|999999"));
-    Assert.assertFalse(function.evaluate("999999", "9999999|99999999"));
+    Assert.assertTrue(function.evaluate(999999, "99999|9999999", intSchema));
+    Assert.assertTrue(function.evaluate(999999, "999999|9999999", intSchema));
+    Assert.assertTrue(function.evaluate(999999, "9999|999999", intSchema));
+    Assert.assertFalse(function.evaluate(999999, "9999999|99999999", intSchema));
     try {
-      Assert.assertFalse(function.evaluate("9999", "9999"));
+      Assert.assertFalse(function.evaluate(9999, "9999", intSchema));
       Assert.fail("Expected function to fail when only one of lower and upper bound is specified");
     } catch (IllegalArgumentException e) {
       // expected
     }
     try {
-      Assert.assertFalse(function.evaluate("9999", "9999|99999|99999"));
+      Assert.assertFalse(function.evaluate(9999, "9999|99999|99999", intSchema));
       Assert.fail("Expected function to fail when more than lower and upper bound is specified");
     } catch (IllegalArgumentException e) {
       // expected
     }
     try {
-      Assert.assertFalse(function.evaluate("9999", "val"));
+      Assert.assertFalse(function.evaluate(9999, "val1|val2", intSchema));
       Assert.fail("Expected function to fail for non-numeric value");
     } catch (IllegalArgumentException e) {
       // expected
     }
     function = new BasicRoutingFunctions.NumberNotBetweenFunction();
-    Assert.assertTrue(function.evaluate("999999", "999999999|999999999999"));
-    Assert.assertFalse(function.evaluate("999999", "999999|999999999999"));
-    Assert.assertFalse(function.evaluate("999999", "9999|999999"));
-    Assert.assertFalse(function.evaluate("999999", "9999|99999999"));
+    Assert.assertTrue(function.evaluate(3.14f, "3.11|3.13", floatSchema));
+    Assert.assertFalse(function.evaluate(3.14f, "3.12|3.14", floatSchema));
+    Assert.assertFalse(function.evaluate(999999, "9999|999999", intSchema));
+    Assert.assertFalse(function.evaluate(999999, "9999|99999999", intSchema));
     try {
-      Assert.assertFalse(function.evaluate("9999", "9999"));
+      Assert.assertFalse(function.evaluate(3.14, "3.14", doubleSchema));
       Assert.fail("Expected function to fail when only one of lower and upper bound is specified");
     } catch (IllegalArgumentException e) {
       // expected
     }
     try {
-      Assert.assertFalse(function.evaluate("9999", "9999|99999|99999"));
+      Assert.assertFalse(function.evaluate(3.14, "9999|99999|99999", doubleSchema));
       Assert.fail("Expected function to fail when more than lower and upper bound is specified");
     } catch (IllegalArgumentException e) {
       // expected
     }
     try {
-      Assert.assertFalse(function.evaluate("9999", "val"));
+      Assert.assertFalse(function.evaluate(9999, "val1|val2", intSchema));
       Assert.fail("Expected function to fail for non-numeric value");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testNumericFunctionsWithDecimals() {
+    String decimalText = "9999999999.99998";
+    String lower = "9999999999.99997";
+    String upper = "9999999999.99999";
+    BigDecimal decimal = new BigDecimal(decimalText);
+    BasicRoutingFunction function = new BasicRoutingFunctions.NumberEqualsFunction();
+    Schema decimalSchema = Schema.decimalOf(20, 5);
+    Assert.assertTrue(function.evaluate(decimal, decimalText, decimalSchema));
+    Assert.assertFalse(function.evaluate(decimal, lower, decimalSchema));
+    try {
+      Assert.assertFalse(function.evaluate(decimal, "val", decimalSchema));
+      Assert.fail("Expected function to fail for non-numeric value");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    function = new BasicRoutingFunctions.NumberBetweenFunction();
+    Assert.assertTrue(function.evaluate(decimal, String.format("%s|%s", lower, upper), decimalSchema));
+    Assert.assertTrue(function.evaluate(decimal, String.format("%s|%s", lower, decimalText), decimalSchema));
+    Assert.assertFalse(function.evaluate(decimal, String.format("%s|%s", upper, upper), decimalSchema));
+  }
+
+  @Test
+  public void testDateFunctions() {
+    // Epoch 1588575800 = LocalDateTime 2020-05-04T00:03:20
+    LocalDate date = LocalDate.of(2020, Month.MAY, 4);
+    BasicRoutingFunction function = new BasicRoutingFunctions.DateEqualsFunction();
+    Schema dateSchema = Schema.of(Schema.LogicalType.DATE);
+    Assert.assertTrue(function.evaluate(date, "2020-05-04", dateSchema));
+    Assert.assertFalse(function.evaluate(date, "2020-05-02", dateSchema));
+    try {
+      Assert.assertFalse(function.evaluate(date, "20200502", dateSchema));
+      Assert.fail("Should have failed for a non-ISO-8601 date format");
+    } catch (DateTimeParseException e) {
+      // expected
+    }
+    function = new BasicRoutingFunctions.DateNotEqualsFunction();
+    LocalTime time = LocalTime.of(0, 3, 20);
+    Schema timeMillisSchema = Schema.of(Schema.LogicalType.TIME_MILLIS);
+    Assert.assertTrue(function.evaluate(time, "10:15:30", timeMillisSchema));
+    Assert.assertFalse(function.evaluate(time, "00:03:20", timeMillisSchema));
+    try {
+      Assert.assertFalse(function.evaluate(time, "00:03:20432", timeMillisSchema));
+      Assert.fail("Should have failed for a non-ISO-8601 date format");
+    } catch (DateTimeParseException e) {
+      // expected
+    }
+    function = new BasicRoutingFunctions.DateAfterFunction();
+    Schema timeMicrosSchema = Schema.of(Schema.LogicalType.TIME_MICROS);
+    Assert.assertTrue(function.evaluate(time, "00:00:00", timeMicrosSchema));
+    Assert.assertFalse(function.evaluate(time, "00:03:20", timeMicrosSchema));
+    Assert.assertFalse(function.evaluate(time, "00:04:20", timeMicrosSchema));
+    try {
+      Assert.assertFalse(function.evaluate(time, "00:0432:20", timeMicrosSchema));
+      Assert.fail("Should have failed for a non-ISO-8601 date format");
+    } catch (DateTimeParseException e) {
+      // expected
+    }
+    function = new BasicRoutingFunctions.DateAfterOrOnFunction();
+    ZonedDateTime zonedDateTime = ZonedDateTime.of(date, time, ZoneId.systemDefault());
+    Schema timestampMillisSchema = Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS);
+    Assert.assertTrue(function.evaluate(zonedDateTime, "2020-05-02T00:03:20-07:00[America/Los_Angeles]",
+                                        timestampMillisSchema));
+    Assert.assertTrue(function.evaluate(zonedDateTime, "2020-05-04T00:02:20-07:00[America/Los_Angeles]",
+                                        timestampMillisSchema));
+    Assert.assertTrue(function.evaluate(zonedDateTime, "2020-05-04T00:03:20-07:00[America/Los_Angeles]",
+                                        timestampMillisSchema));
+    Assert.assertFalse(function.evaluate(zonedDateTime, "2020-05-04T00:03:21-07:00[America/Los_Angeles]",
+                                         timestampMillisSchema));
+    Assert.assertFalse(function.evaluate(zonedDateTime, "2020-05-05T00:03:21-07:00[America/Los_Angeles]",
+                                         timestampMillisSchema));
+    try {
+      Assert.assertFalse(function.evaluate(zonedDateTime, "20200502000320-0700", timestampMillisSchema));
+      Assert.fail("Should have failed for a non-ISO-8601 date format");
+    } catch (DateTimeParseException e) {
+      // expected
+    }
+    function = new BasicRoutingFunctions.DateBeforeFunction();
+    Schema timestampMicrosSchema = Schema.of(Schema.LogicalType.TIMESTAMP_MICROS);
+    Assert.assertTrue(function.evaluate(zonedDateTime, "2020-05-04T00:03:21-07:00[America/Los_Angeles]",
+                                        timestampMicrosSchema));
+    Assert.assertFalse(function.evaluate(zonedDateTime, "2020-05-04T00:03:20-07:00[America/Los_Angeles]",
+                                         timestampMicrosSchema));
+    Assert.assertFalse(function.evaluate(zonedDateTime, "2020-05-02T00:03:19-07:00[America/Los_Angeles]",
+                                         timestampMicrosSchema));
+    try {
+      Assert.assertFalse(function.evaluate(zonedDateTime, "20200502000320-0700", timestampMicrosSchema));
+      Assert.fail("Should have failed for a non-ISO-8601 date format");
+    } catch (DateTimeParseException e) {
+      // expected
+    }
+    function = new BasicRoutingFunctions.DateBeforeOrOnFunction();
+    Assert.assertTrue(function.evaluate(date, "2020-05-05", dateSchema));
+    Assert.assertTrue(function.evaluate(date, "2020-05-04", dateSchema));
+    Assert.assertFalse(function.evaluate(date, "2020-05-02", dateSchema));
+    try {
+      Assert.assertFalse(function.evaluate(date, "20200502", dateSchema));
+      Assert.fail("Should have failed for a non-ISO-8601 date format");
+    } catch (DateTimeParseException e) {
+      // expected
+    }
+    function = new BasicRoutingFunctions.DateBetweenFunction();
+    Assert.assertTrue(function.evaluate(date, "2020-05-03|2020-05-05", dateSchema));
+    Assert.assertTrue(function.evaluate(date, "2020-05-04|2020-05-04", dateSchema));
+    Assert.assertFalse(function.evaluate(date, "2020-05-02|2020-05-03", dateSchema));
+    try {
+      Assert.assertFalse(function.evaluate(date, "2020-05-02", dateSchema));
+      Assert.fail("Should have failed because only lower bound was specified");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      Assert.assertFalse(function.evaluate(date, "2020-05-02|2020-05-05|2020-05-08", dateSchema));
+      Assert.fail("Should have failed because 3 bounds were specified");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    function = new BasicRoutingFunctions.DateNotBetweenFunction();
+    Assert.assertTrue(function.evaluate(date, "2020-05-05|2020-05-06", dateSchema));
+    Assert.assertFalse(function.evaluate(date, "2020-05-04|2020-05-04", dateSchema));
+    Assert.assertFalse(function.evaluate(date, "2020-05-02|2020-05-05", dateSchema));
+    try {
+      Assert.assertFalse(function.evaluate(date, "2020-05-02", dateSchema));
+      Assert.fail("Should have failed because only lower bound was specified");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      Assert.assertFalse(function.evaluate(date, "2020-05-02|2020-05-05|2020-05-08", dateSchema));
+      Assert.fail("Should have failed because 3 bounds were specified");
     } catch (IllegalArgumentException e) {
       // expected
     }

--- a/src/test/java/io/cdap/plugin/switchcase/route/BasicRoutingSwitchTest.java
+++ b/src/test/java/io/cdap/plugin/switchcase/route/BasicRoutingSwitchTest.java
@@ -17,12 +17,8 @@
 package io.cdap.plugin.switchcase.route;
 
 import io.cdap.cdap.api.data.format.StructuredRecord;
-import io.cdap.cdap.api.data.schema.Schema;
 import io.cdap.cdap.etl.api.InvalidEntry;
-import io.cdap.cdap.etl.api.MultiOutputPipelineConfigurer;
 import io.cdap.cdap.etl.api.SplitterTransform;
-import io.cdap.cdap.etl.api.StageContext;
-import io.cdap.cdap.etl.api.TransformContext;
 import io.cdap.cdap.etl.api.validation.ValidationException;
 import io.cdap.cdap.etl.api.validation.ValidationFailure;
 import io.cdap.cdap.etl.mock.common.MockMultiOutputEmitter;
@@ -30,6 +26,13 @@ import io.cdap.cdap.etl.mock.transform.MockTransformContext;
 import io.cdap.cdap.etl.mock.validation.MockFailureCollector;
 import org.junit.Assert;
 import org.junit.Test;
+import java.math.BigDecimal;
+import java.nio.charset.Charset;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -140,12 +143,112 @@ public class BasicRoutingSwitchTest extends RoutingSwitchTest {
     Assert.assertTrue(validateFunction("number_lesser_than_or_equals").isEmpty());
     Assert.assertTrue(validateFunction("number_between").isEmpty());
     Assert.assertTrue(validateFunction("number_not_between").isEmpty());
+    Assert.assertTrue(validateFunction("date_equals").isEmpty());
+    Assert.assertTrue(validateFunction("date_not_equals").isEmpty());
+    Assert.assertTrue(validateFunction("date_after").isEmpty());
+    Assert.assertTrue(validateFunction("date_after_or_on").isEmpty());
+    Assert.assertTrue(validateFunction("date_before").isEmpty());
+    Assert.assertTrue(validateFunction("date_before_or_on").isEmpty());
+    Assert.assertTrue(validateFunction("date_between").isEmpty());
+    Assert.assertTrue(validateFunction("date_not_between").isEmpty());
     try {
       validateFunction("blah");
       Assert.fail("Validation should fail for invalid function");
     } catch (ValidationException e) {
       // expected
     }
+  }
+
+  @Test
+  public void testRoutingFieldSchemas() throws Exception {
+    // Make sure that all supported types can be accepted while the pipeline runs
+    StructuredRecord inner = StructuredRecord.builder(INPUT)
+      .set("supplier_id", "1")
+      .set("part_id", "2")
+      .set("count", 3)
+      .build();
+
+    LocalDate testDate = LocalDate.of(2020, 5, 4);
+    LocalTime testTimeMillis = LocalTime.of(1, 2, 3);
+    LocalTime testTimeMicros = LocalTime.of(4, 5, 6);
+    StructuredRecord testRecord = StructuredRecord.builder(ALL_TYPES_SCHEMA)
+      .set("supplier_id", "supplier1")
+      .set("string", "test")
+      .set("int", 1)
+      .set("long", 2L)
+      .set("float", 3.14f)
+      .set("double", 3.14)
+      .set("boolean", true)
+      .set("bytes", "bytes".getBytes(Charset.defaultCharset()))
+      .set("union", 3)
+      .set("enum", "ENUM1")
+      .set("map", Collections.EMPTY_MAP)
+      .set("array", new int[] {4, 5})
+      .set("record", inner)
+      .setDate("date", testDate)
+      .setTime("time_millis", testTimeMillis)
+      .setTime("time_micros", testTimeMicros)
+      .setTimestamp("timestamp_millis", ZonedDateTime.of(testDate, testTimeMillis, ZoneId.systemDefault()))
+      .setTimestamp("timestamp_micros", ZonedDateTime.of(testDate, testTimeMicros, ZoneId.systemDefault()))
+      .setDecimal("decimal", new BigDecimal("9999999.998"))
+      .build();
+
+    MockMultiOutputEmitter<StructuredRecord> emitter = new MockMultiOutputEmitter<>();
+    runSingleRecord(testRecord, "string", "portA:ends_with(lierA)", emitter);
+    runSingleRecord(testRecord, "int", "portA:number_lesser_than(2)", emitter);
+    runSingleRecord(testRecord, "long", "portA:number_greater_than(1)", emitter);
+    runSingleRecord(testRecord, "float", "portA:number_greater_than_or_equals(1.3)", emitter);
+    runSingleRecord(testRecord, "double", "portA:number_lesser_than_or_equals(1.6)", emitter);
+    try {
+      runSingleRecord(testRecord, "boolean", "portA:equals(true)", emitter);
+      Assert.fail("Routing on boolean fields is not supported, so should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      runSingleRecord(testRecord, "bytes", "portA:equals(bytes)", emitter);
+      Assert.fail("Routing on bytes fields is not supported, so should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      runSingleRecord(testRecord, "union", "portA:number_between(3|4)", emitter);
+      Assert.fail("Routing on union fields is not supported, so should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      runSingleRecord(testRecord, "enum", "portA:starts_with(EN)", emitter);
+      Assert.fail("Routing on enum fields is not supported, so should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      runSingleRecord(testRecord, "map", "portA:ends_with(1)", emitter);
+      Assert.fail("Routing on map fields is not supported, so should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      runSingleRecord(testRecord, "array", "portA:number_not_between(1|9)", emitter);
+      Assert.fail("Routing on array fields is not supported, so should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    try {
+      runSingleRecord(testRecord, "record", "portA:number_lesser_than_or_equals(9)", emitter);
+      Assert.fail("Routing on record fields is not supported, so should fail");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+    runSingleRecord(testRecord, "date", "portA:date_after_or_on(2020-05-04)", emitter);
+    runSingleRecord(testRecord, "time_millis", "portA:date_before_or_on(02:03:04)", emitter);
+    runSingleRecord(testRecord, "time_micros", "portA:date_after(00:01:02)", emitter);
+    runSingleRecord(testRecord, "timestamp_millis",
+                    "portA:date_after_or_on(2020-05-02T00:03:20-07:00[America/Los_Angeles])", emitter);
+    runSingleRecord(testRecord, "timestamp_micros",
+                    "portA:date_after_or_on(2020-05-02T00:03:20-07:00[America/Los_Angeles])", emitter);
+    runSingleRecord(testRecord, "decimal", "portA:number_between(9999999.997|9999999.999)", emitter);
   }
 
   private void testNullRecordToNullPort(@Nullable String nullPortName) throws Exception {
@@ -194,20 +297,24 @@ public class BasicRoutingSwitchTest extends RoutingSwitchTest {
       .set("count", "3")
       .build();
 
-    RoutingSwitch.Config config = new RoutingSwitch.Config(
-      "supplier_id", portSpecification, null, null, null, null
-    );
-    SplitterTransform<StructuredRecord, StructuredRecord> routingSwitch = new RoutingSwitch(config);
-    routingSwitch.initialize(new MockTransformContext());
-
     MockMultiOutputEmitter<StructuredRecord> emitter = new MockMultiOutputEmitter<>();
-    routingSwitch.transform(testRecord, emitter);
+    runSingleRecord(testRecord, "supplier_id", portSpecification, emitter);
 
     List<Object> objects = emitter.getEmitted().get(portToRouteTo);
     StructuredRecord record = (StructuredRecord) objects.get(0);
     Assert.assertEquals(testRecord, record);
     objects = emitter.getEmitted().get(portToNotRouteTo);
     Assert.assertNull(objects);
+  }
+
+  private void runSingleRecord(StructuredRecord record, String routingField, String portSpecification,
+                               MockMultiOutputEmitter<StructuredRecord> emitter) throws Exception {
+    RoutingSwitch.Config config = new RoutingSwitch.Config(
+      routingField, portSpecification, null, null, null, null
+    );
+    SplitterTransform<StructuredRecord, StructuredRecord> routingSwitch = new RoutingSwitch(config);
+    routingSwitch.initialize(new MockTransformContext());
+    routingSwitch.transform(record, emitter);
   }
 
   private List<ValidationFailure> validateFunction(String functionName) {

--- a/src/test/java/io/cdap/plugin/switchcase/route/RoutingSwitchTest.java
+++ b/src/test/java/io/cdap/plugin/switchcase/route/RoutingSwitchTest.java
@@ -71,7 +71,23 @@ public abstract class RoutingSwitchTest {
                                                            Schema.recordOf(
                                                              "record", Objects.requireNonNull(INPUT.getFields())
                                                            )
-                                                         ));
+                                                         ),
+                                                         Schema.Field.of("date", Schema.of(Schema.LogicalType.DATE)),
+                                                         Schema.Field.of(
+                                                           "time_millis", Schema.of(Schema.LogicalType.TIME_MILLIS)
+                                                         ),
+                                                         Schema.Field.of(
+                                                           "time_micros", Schema.of(Schema.LogicalType.TIME_MICROS)
+                                                         ),
+                                                         Schema.Field.of(
+                                                           "timestamp_millis",
+                                                           Schema.of(Schema.LogicalType.TIMESTAMP_MILLIS)
+                                                         ),
+                                                         Schema.Field.of(
+                                                           "timestamp_micros",
+                                                           Schema.of(Schema.LogicalType.TIMESTAMP_MICROS)
+                                                         ),
+                                                         Schema.Field.of("decimal", Schema.decimalOf(10, 3)));
 
   // TODO: Add an abstract method getMode(), so test can be executed for all modes after adding jexl support
 
@@ -146,13 +162,19 @@ public abstract class RoutingSwitchTest {
 
   @Test
   public void testAllowedTypes() {
+    // Make sure that all supported types can be validated during design time
     Assert.assertTrue(validateType("string").isEmpty());
     Assert.assertTrue(validateType("int").isEmpty());
     Assert.assertTrue(validateType("long").isEmpty());
     Assert.assertTrue(validateType("float").isEmpty());
     Assert.assertTrue(validateType("double").isEmpty());
+    Assert.assertTrue(validateType("bytes").isEmpty());
+    Assert.assertTrue(validateType("date").isEmpty());
+    Assert.assertTrue(validateType("time_millis").isEmpty());
+    Assert.assertTrue(validateType("time_micros").isEmpty());
+    Assert.assertTrue(validateType("timestamp_millis").isEmpty());
+    Assert.assertTrue(validateType("timestamp_micros").isEmpty());
     Assert.assertEquals(1, validateType("boolean").size());
-    Assert.assertEquals(1, validateType("bytes").size());
     Assert.assertEquals(1, validateType("union").size());
     Assert.assertEquals(1, validateType("enum").size());
     Assert.assertEquals(1, validateType("map").size());

--- a/widgets/RoutingSwitch-splittertransform.json
+++ b/widgets/RoutingSwitch-splittertransform.json
@@ -96,6 +96,46 @@
               {
                 "label": "Number Lesser Than or Equals",
                 "value": "number_lesser_than_or_equals"
+              },
+              {
+                "label": "Number Between",
+                "value": "number_between"
+              },
+              {
+                "label": "Number Not Between",
+                "value": "number_not_between"
+              },
+              {
+                "label": "Date Equals",
+                "value": "date_equals"
+              },
+              {
+                "label": "Date Not Equals",
+                "value": "date_not_equals"
+              },
+              {
+                "label": "Date After",
+                "value": "date_after"
+              },
+              {
+                "label": "Date After or On",
+                "value": "date_after_or_on"
+              },
+              {
+                "label": "Date Before",
+                "value": "date_before"
+              },
+              {
+                "label": "Date Before or On",
+                "value": "date_before_or_on"
+              },
+              {
+                "label": "Date Between",
+                "value": "date_between"
+              },
+              {
+                "label": "Date Not Between",
+                "value": "date_not_between"
               }
             ]
           },


### PR DESCRIPTION
1. Changed the parsing logic to rely upon the schema instead of converting everything into a String first, and then doing guesswork for numbers using ``BigDecimal``. It adds a `Schema` argument to the ``BasicRoutingFunction``, which dictates the parsing for all data. In doing so, it removes unnecessary type conversions - first from a numeric type to its String value, and then into a BigDecimal.
2. Added support for date-based functions. It uses the `Schema.LogicalType` from the `Schema` argument to the ``BasicRoutingFunction``, to parse for dates.
3. Added support for ``BigDecimal`` fields.